### PR TITLE
Improve Knob Grabbing

### DIFF
--- a/com/smartg/swing/JRangeSlider.java
+++ b/com/smartg/swing/JRangeSlider.java
@@ -40,6 +40,18 @@ import com.smartg.java.util.EventListenerListIterator;
  */
 public class JRangeSlider extends JPanel {
 
+    // used to get access to protected goodies
+
+    private final class RangeSliderUI extends BasicSliderUI {
+	public RangeSliderUI(JSlider slider) {
+	   super(slider);
+	}
+	Rectangle getThumbRect() {
+	    calculateThumbLocation();
+	    return new Rectangle(this.thumbRect);
+	}
+    }
+
     private final class MouseHandler extends MouseAdapter {
 	private int cursorType;
 	private int pressX, pressY;
@@ -48,34 +60,19 @@ public class JRangeSlider extends JPanel {
 
 	@Override
 	public void mouseMoved(MouseEvent e) {
-	    switch (slider.getOrientation()) {
-	    case SwingConstants.HORIZONTAL:
-		int x = (int) (e.getX() * scaleX);
-		if (Math.abs(x - (model.getValue() + model.getExtent())) < 3) {
-		    cursorType = Cursor.E_RESIZE_CURSOR;
-		} else if (Math.abs(x - model.getValue()) < 3) {
-		    cursorType = Cursor.W_RESIZE_CURSOR;
-		} else if (x > model.getValue() && x < (model.getValue() + model.getExtent())) {
-		    cursorType = Cursor.MOVE_CURSOR;
-		} else {
-		    cursorType = Cursor.DEFAULT_CURSOR;
-		}
-		setCursor(Cursor.getPredefinedCursor(cursorType));
-		break;
-	    case SwingConstants.VERTICAL:
-		int y = (int) ((getHeight() - e.getY()) * scaleY);
-		if (Math.abs(y - (model.getValue() + model.getExtent())) < 3) {
-		    cursorType = Cursor.N_RESIZE_CURSOR;
-		} else if (Math.abs(y - model.getValue()) < 3) {
-		    cursorType = Cursor.S_RESIZE_CURSOR;
-		} else if (y > model.getValue() && y < (model.getValue() + model.getExtent())) {
-		    cursorType = Cursor.MOVE_CURSOR;
-		} else {
-		    cursorType = Cursor.DEFAULT_CURSOR;
-		}
-		setCursor(Cursor.getPredefinedCursor(cursorType));
-		break;
+	    int x = e.getX();
+	    int y = e.getY();
+	    boolean horizontal = (slider.getOrientation() == SwingConstants.HORIZONTAL);
+	    if (upperThumbRect.contains(x,y)) {
+		cursorType = horizontal ? Cursor.E_RESIZE_CURSOR : Cursor.N_RESIZE_CURSOR;
+	    } else if (lowerThumbRect.contains(x,y)) {
+		cursorType = horizontal ? Cursor.W_RESIZE_CURSOR : Cursor.S_RESIZE_CURSOR;
+	    } else if (middleRect.contains(x,y)) {
+		cursorType = Cursor.MOVE_CURSOR;
+	    } else {
+		cursorType = Cursor.DEFAULT_CURSOR;
 	    }
+	    setCursor(Cursor.getPredefinedCursor(cursorType));
 	}
 
 	@Override
@@ -154,6 +151,7 @@ public class JRangeSlider extends JPanel {
 
     private MouseHandler mouseHandler = new MouseHandler();
     private float scaleX, scaleY;
+    private Rectangle lowerThumbRect, middleRect, upperThumbRect;
 
     private JSlider slider = new JSlider();
 
@@ -167,6 +165,7 @@ public class JRangeSlider extends JPanel {
 	model.setValue(value);
 	model.setExtent(extent);
 
+	slider.setUI(new RangeSliderUI(slider));
 	slider.setMinimum(min);
 	slider.setMaximum(max);
 
@@ -239,12 +238,13 @@ public class JRangeSlider extends JPanel {
 	slider.setBounds(getBounds());
 	
 	slider.setValue(0);
-	BasicSliderUI ui = (BasicSliderUI) slider.getUI();
+	RangeSliderUI ui = (RangeSliderUI) slider.getUI();
 	if(getPaintTrack()) {
 	    ui.paintTrack(g);
 	}
 
 	slider.setValue(model.getValue() + model.getExtent());
+	upperThumbRect = ui.getThumbRect();
 
 	Rectangle clip = g.getClipBounds();
 
@@ -264,7 +264,18 @@ public class JRangeSlider extends JPanel {
 	}
 	
 	slider.setValue(model.getValue());
+	lowerThumbRect = ui.getThumbRect();
 	ui.paintThumb(g);
+
+	middleRect = new Rectangle(lowerThumbRect);
+	switch (slider.getOrientation()) {
+	    case SwingConstants.HORIZONTAL:
+		middleRect.width = upperThumbRect.x - lowerThumbRect.x;
+		break;
+	    case SwingConstants.VERTICAL:
+		middleRect.height = upperThumbRect.y - lowerThumbRect.y;
+		break;
+	}
     }
 
     private void computeScaleX() {


### PR DESCRIPTION
Thanks for this neat little library. I wanted to use a RangeSlider but JIDE was too big of a dependency for just one item and https://ernienotes.wordpress.com/2010/12/27/creating-a-java-swing-range-slider/ lacked features like ticks because of the custom ui. Yours fit the bill nicely. It's a shame more people have not found it :+1: 

Unfortunately in my testing I found that grabbing the knobs was very awkward. With the default parameters the range was way too small, forcing you to put your cursor towards the inside of the handles. If you put it in the middle or towards the outside your grabs would be ignored. I tried tweaking the constants in mouseMoved but ended up with strange results. With larger values you could grab the knobs past their rendered image on the outer sides, yet still not be able to grab the very inner images. It was clear there was some issue with the math/scaling not centering around the knobs correctly.

On a hunt for clues I looked at BasicSliderUI to see how they determined if a knob was grabbed. It turns out that they use rectangle clipping detection to check if the mouse is over the image. Unfortunately the rectangles it was using were protected and unable to be accessed from your code. However, by using a custom subclass of BasicSliderUI I made a public function to access the protected variable. With access to these variables checking for the various states became trivial.

With these changes grabbing the knobs works perfectly both horizontally and vertically. In my mind not using magic constants is a good thing; what if swing changed their images to a larger one? Suddenly the old acceptable range of '3' would be even more broken. With the rectangle clipping this issue is no longer present.

I hope this change helps you (future) others.
