### PR TITLE
Fix Scaling After Changing Range

### DIFF
--- a/com/smartg/swing/JRangeSlider.java
+++ b/com/smartg/swing/JRangeSlider.java
@@ -428,6 +428,8 @@ public class JRangeSlider extends JPanel {
     public void setMaximum(int maximum) {
 	model.setMaximum(maximum);
 	slider.setMaximum(maximum);
+	computeScaleX();
+	computeScaleY();
     }
 
     public int getMinimum() {
@@ -437,6 +439,8 @@ public class JRangeSlider extends JPanel {
     public void setMinimum(int minimum) {
 	model.setMinimum(minimum);
 	slider.setMinimum(minimum);
+	computeScaleX();
+	computeScaleY();
     }
 
     public BoundedRangeModel getModel() {
@@ -447,6 +451,8 @@ public class JRangeSlider extends JPanel {
 	this.model = newModel;
 	slider.setMinimum(model.getMinimum());
 	slider.setMaximum(model.getMaximum());
+	computeScaleX();
+	computeScaleY();
     }
 
     public ChangeListener[] getChangeListeners() {


### PR DESCRIPTION
computeScale{X,Y} depends on the model's min and max. However, when the min or max change the scaling does not. Ex: Without this patch make a slider from 0-100 then call setMaximum(10000) and try dragging it; the knobs will barely move. This fixes that.
